### PR TITLE
Fix Build under GCC Version 13

### DIFF
--- a/inc/Instruction.h
+++ b/inc/Instruction.h
@@ -11,6 +11,7 @@
 
 #include "systemc"
 #include "extension_base.h"
+#include <cstdint>
 
 namespace riscv_tlm {
 

--- a/inc/MemoryInterface.h
+++ b/inc/MemoryInterface.h
@@ -16,6 +16,7 @@
 #include "tlm_utils/tlm_quantumkeeper.h"
 
 #include "memory.h"
+#include <cstdint>
 
 namespace riscv_tlm {
 

--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "Timer.h"
+#include <cstdint>
 
 namespace riscv_tlm::peripherals {
 


### PR DESCRIPTION
Fixing missing Include statements under GCC 13.

Fixes `std::uint32_t` undefined compilation error under GCC 13.
